### PR TITLE
bulker: add prefix env var for `in.id` topics

### DIFF
--- a/.docs/server-config.md
+++ b/.docs/server-config.md
@@ -6,7 +6,7 @@
 * [Batching](#batching)
 * [Streaming](#streaming)
 * [Error Handling and Retries](#error-handling-and-retries)
-* [Advanced Kafka Tuning](#kafka-topic-management--advanced-)
+* [Advanced Kafka Tuning](#kafka-topic-management)
 * [Events Log](#events-log) *(optional)*
 * [Defining Destination](#defining-destinations)
   * [Postgres / MySQL / Redshift / Snowflake credentials](#postgres--mysql--redshift--snowflake-credentials)
@@ -170,9 +170,9 @@ Read more about batch processing configuration [below](#defining-destinations)
 Default batch size for destination's Retry Consumer where `retryBatchSize` is not set explicitly.
 Read more about batch processing configuration [below](#defining-destinations)
 
-## Kafka topic management (advanced)
+## Kafka topic management
 
-Bulker automatically creates 3 topics per each table in destination. One topic is for main processing, one is for failed events that should be retried and the last one for failed events that won't be retried - dead. The topic names has format `in.id.{destiantionId}.m.{mode}.t.{tableName}`.
+Bulker automatically creates 3 topics per each table in destination. One topic is for main processing, one is for failed events that should be retried and the last one for failed events that won't be retried - dead. The topic names has format `in.id.{destinationId}.m.{mode}.t.{tableName}`.
 
 Mode can be: `batch` or `stream`, `retry`, `dead`.
 
@@ -183,6 +183,8 @@ Parameters above define how topics are created
 *Optional, default value: `` (none)*
 
 String prefixed to all destination topic names.
+
+e.g. if `BULKER_KAFKA_TOPIC_PREFIX=some.prefix.`, then a full topic name could be `some.prefix.in.id.clyzlw-.m.batch.t.events`
 
 ### `BULKER_KAFKA_TOPIC_RETENTION_HOURS`
 

--- a/.docs/server-config.md
+++ b/.docs/server-config.md
@@ -178,6 +178,12 @@ Mode can be: `batch` or `stream`, `retry`, `dead`.
 
 Parameters above define how topics are created
 
+### `BULKER_KAFKA_TOPIC_PREFIX`
+
+*Optional, default value: `` (none)*
+
+String prefixed to all destination topic names.
+
 ### `BULKER_KAFKA_TOPIC_RETENTION_HOURS`
 
 *Optional, default value: `168` (7 days)*

--- a/bulkerapp/app/abstract_consumer.go
+++ b/bulkerapp/app/abstract_consumer.go
@@ -56,7 +56,7 @@ func (ac *AbstractConsumer) SendMetrics(metricsMeta string, status string, event
 	if metricsDst == nil {
 		return
 	}
-	topicId, err := metricsDst.TopicId("metrics", "", "")
+	topicId, err := metricsDst.TopicId("metrics", "", ac.config.KafkaTopicPrefix)
 	if err != nil {
 		ac.Errorf("Error getting topicId for metrics destination: %v", err)
 		return

--- a/bulkerapp/app/abstract_consumer.go
+++ b/bulkerapp/app/abstract_consumer.go
@@ -3,13 +3,14 @@ package app
 import (
 	"crypto/md5"
 	"fmt"
+	"math"
+	"time"
+
 	kafka2 "github.com/confluentinc/confluent-kafka-go/v2/kafka"
 	"github.com/jitsucom/bulker/jitsubase/appbase"
 	"github.com/jitsucom/bulker/jitsubase/jsoniter"
 	"github.com/jitsucom/bulker/jitsubase/timestamp"
 	"github.com/jitsucom/bulker/jitsubase/uuid"
-	"math"
-	"time"
 )
 
 const MetricsMetaHeader = "metrics_meta"
@@ -55,7 +56,7 @@ func (ac *AbstractConsumer) SendMetrics(metricsMeta string, status string, event
 	if metricsDst == nil {
 		return
 	}
-	topicId, err := metricsDst.TopicId("metrics", "")
+	topicId, err := metricsDst.TopicId("metrics", "", "")
 	if err != nil {
 		ac.Errorf("Error getting topicId for metrics destination: %v", err)
 		return

--- a/bulkerapp/app/batch_consumer.go
+++ b/bulkerapp/app/batch_consumer.go
@@ -160,7 +160,7 @@ func (bc *BatchConsumerImpl) processBatchImpl(destination *Destination, batchNum
 			bc.pause(true)
 		})
 
-		bc.Infof("Batch #%d Committing %d events to %s", batchNum, processed, destination.destinationConfig.BulkerType)
+		bc.Infof("Batch #%d Committing %d events to %s", batchNum, processed, destination.config.BulkerType)
 		//TODO: do we need to interrupt commit if consumer is retired?
 		state, err = bulkerStream.Complete(ctx)
 		pauseTimer.Stop()
@@ -168,7 +168,7 @@ func (bc *BatchConsumerImpl) processBatchImpl(destination *Destination, batchNum
 		bc.postEventsLog(state, processedObjectSample, err)
 		if err != nil {
 			failedPosition = &latestMessage.TopicPartition
-			return counters, state, false, bc.NewError("Failed to commit bulker stream to %s: %v", destination.destinationConfig.BulkerType, err)
+			return counters, state, false, bc.NewError("Failed to commit bulker stream to %s: %v", destination.config.BulkerType, err)
 		}
 		counters.processed = processed
 		_, err = bc.consumer.Load().CommitMessage(latestMessage)

--- a/bulkerapp/app/repository.go
+++ b/bulkerapp/app/repository.go
@@ -63,11 +63,11 @@ func (r *Repository) init() error {
 	for id, oldDestination := range oldDestinations {
 		newDst, ok := internal.destinations[id]
 		if !ok {
-			r.Infof("Destination %s (%s) was removed. Ver: %s", id, oldDestination.destinationConfig.BulkerType, oldDestination.destinationConfig.UpdatedAt)
+			r.Infof("Destination %s (%s) was removed. Ver: %s", id, oldDestination.config.BulkerType, oldDestination.config.UpdatedAt)
 			toRetire = append(toRetire, oldDestination)
 			repositoryChange.RemovedDestinationIds = append(repositoryChange.RemovedDestinationIds, id)
 		} else if !newDst.equals(oldDestination) {
-			r.Infof("Destination %s (%s) was updated. New Ver: %s", id, newDst.destinationConfig.BulkerType, newDst.destinationConfig.UpdatedAt)
+			r.Infof("Destination %s (%s) was updated. New Ver: %s", id, newDst.config.BulkerType, newDst.config.UpdatedAt)
 			toRetire = append(toRetire, oldDestination)
 			repositoryChange.ChangedDestinations = append(repositoryChange.ChangedDestinations, newDst)
 		} else {
@@ -78,7 +78,7 @@ func (r *Repository) init() error {
 	for id, dst := range internal.destinations {
 		_, ok := oldDestinations[id]
 		if !ok {
-			r.Infof("Destination %s (%s) was added. Ver: %s", id, dst.destinationConfig.BulkerType, dst.destinationConfig.UpdatedAt)
+			r.Infof("Destination %s (%s) was added. Ver: %s", id, dst.config.BulkerType, dst.config.UpdatedAt)
 			repositoryChange.AddedDestinations = append(repositoryChange.AddedDestinations, dst)
 		}
 	}
@@ -157,7 +157,7 @@ func (r *repositoryInternal) addDestination(cfg *DestinationConfig) {
 		options.Add(opt)
 	}
 	configHash, _ := utils.HashAny(cfg)
-	r.destinations[cfg.Id()] = &Destination{destinationConfig: cfg, configHash: configHash, mode: bulker.ModeOption.Get(&options), streamOptions: &options, owner: r}
+	r.destinations[cfg.Id()] = &Destination{config: cfg, configHash: configHash, mode: bulker.ModeOption.Get(&options), streamOptions: &options, owner: r}
 }
 
 func (r *repositoryInternal) GetDestination(id string) *Destination {
@@ -202,12 +202,11 @@ func (r *repositoryInternal) GetDestinations() []*Destination {
 
 type Destination struct {
 	sync.Mutex
-	destinationConfig *DestinationConfig
-	config            *Config
-	configHash        uint64
-	mode              bulker.BulkMode
-	bulker            bulker.Bulker
-	streamOptions     *bulker.StreamOptions
+	config        *DestinationConfig
+	configHash    uint64
+	mode          bulker.BulkMode
+	bulker        bulker.Bulker
+	streamOptions *bulker.StreamOptions
 
 	owner       *repositoryInternal
 	retired     bool
@@ -215,16 +214,16 @@ type Destination struct {
 }
 
 // TopicId generates topic id for Destination
-func (d *Destination) TopicId(tableName string, modeOverride string) (string, error) {
+func (d *Destination) TopicId(tableName string, modeOverride, prefix string) (string, error) {
 	if tableName == "" {
-		tableName = d.destinationConfig.StreamConfig.TableName
+		tableName = d.config.StreamConfig.TableName
 	}
-	return MakeTopicId(d.Id(), utils.DefaultString(modeOverride, string(d.mode)), tableName, d.config.KafkaTopicPrefix, true)
+	return MakeTopicId(d.Id(), utils.DefaultString(modeOverride, string(d.mode)), tableName, prefix, true)
 }
 
 // Id returns destination id
 func (d *Destination) Id() string {
-	return d.destinationConfig.Id()
+	return d.config.Id()
 }
 
 func (d *Destination) InitBulkerInstance() {
@@ -244,7 +243,7 @@ func (d *Destination) InitBulkerInstance() {
 		}
 	}()
 
-	d.bulker, err = bulker.CreateBulker(d.destinationConfig.Config)
+	d.bulker, err = bulker.CreateBulker(d.config.Config)
 	if err != nil {
 		metrics.RepositoryDestinationInitError(d.Id()).Inc()
 		if d.bulker == nil {
@@ -264,7 +263,7 @@ func (d *Destination) Mode() bulker.BulkMode {
 func (d *Destination) retire() {
 	d.retired = true
 	if d.leasesCount == 0 {
-		logging.Infof("[%s] closing retired destination. Ver: %s", d.Id(), d.destinationConfig.UpdatedAt)
+		logging.Infof("[%s] closing retired destination. Ver: %s", d.Id(), d.config.UpdatedAt)
 		if d.bulker != nil {
 			_ = d.bulker.Close()
 		}
@@ -279,7 +278,7 @@ func (d *Destination) incLeases() {
 func (d *Destination) decLeases() {
 	d.leasesCount--
 	if d.retired && d.leasesCount == 0 {
-		logging.Infof("[%s] closing retired destination. Ver: %s", d.Id(), d.destinationConfig.UpdatedAt)
+		logging.Infof("[%s] closing retired destination. Ver: %s", d.Id(), d.config.UpdatedAt)
 		if d.bulker != nil {
 			_ = d.bulker.Close()
 		}
@@ -298,7 +297,7 @@ func (d *Destination) Release() {
 
 // equals compares destination with another destination
 func (d *Destination) equals(o *Destination) bool {
-	return d.configHash == o.configHash && d.destinationConfig.UpdatedAt == o.destinationConfig.UpdatedAt
+	return d.configHash == o.configHash && d.config.UpdatedAt == o.config.UpdatedAt
 }
 
 //// AddBatchConsumer Add batch consumer to destination

--- a/bulkerapp/app/router.go
+++ b/bulkerapp/app/router.go
@@ -124,7 +124,7 @@ func (r *Router) EventsHandler(c *gin.Context) {
 		rError = r.ResponseError(c, http.StatusBadRequest, "missing required parameter", false, fmt.Errorf("tableName query parameter is required"), true)
 		return
 	}
-	topicId, err := destination.TopicId(tableName, mode)
+	topicId, err := destination.TopicId(tableName, mode, r.config.KafkaTopicPrefix)
 	if err != nil {
 		rError = r.ResponseError(c, http.StatusInternalServerError, "couldn't generate topicId", false, err, true)
 		return

--- a/bulkerapp/app/router.go
+++ b/bulkerapp/app/router.go
@@ -3,6 +3,14 @@ package app
 import (
 	"bufio"
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/pprof"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 	"github.com/gin-gonic/gin"
 	"github.com/hjson/hjson-go/v4"
@@ -17,13 +25,6 @@ import (
 	"github.com/jitsucom/bulker/jitsubase/timestamp"
 	"github.com/jitsucom/bulker/jitsubase/utils"
 	"github.com/jitsucom/bulker/jitsubase/uuid"
-	"io"
-	"net/http"
-	"net/http/pprof"
-	"regexp"
-	"strconv"
-	"strings"
-	"time"
 )
 
 var TimestampPattern = regexp.MustCompile(`^\d{13}$`)
@@ -284,7 +285,7 @@ func (r *Router) FailedHandler(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "unknown status: " + status + " (should be '" + retryTopicMode + "' or '" + deadTopicMode + "')"})
 		return
 	}
-	topicId, _ := MakeTopicId(destinationId, status, allTablesToken, false)
+	topicId, _ := MakeTopicId(destinationId, status, allTablesToken, r.config.KafkaTopicPrefix, false)
 	consumerConfig := kafka.ConfigMap(utils.MapPutAll(kafka.ConfigMap{
 		"auto.offset.reset":             "earliest",
 		"group.id":                      uuid.New(),

--- a/bulkerapp/app/stream_consumer.go
+++ b/bulkerapp/app/stream_consumer.go
@@ -3,6 +3,10 @@ package app
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"sync/atomic"
+	"time"
+
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 	"github.com/jitsucom/bulker/bulkerapp/metrics"
 	bulker "github.com/jitsucom/bulker/bulkerlib"
@@ -13,9 +17,6 @@ import (
 	"github.com/jitsucom/bulker/jitsubase/timestamp"
 	"github.com/jitsucom/bulker/jitsubase/utils"
 	"github.com/jitsucom/bulker/kafkabase"
-	"strconv"
-	"sync/atomic"
-	"time"
 )
 
 const streamConsumerMessageWaitTimeout = 5 * time.Second
@@ -180,7 +181,7 @@ func (sc *StreamConsumerImpl) restartConsumer() {
 
 // start consuming messages from kafka
 func (sc *StreamConsumerImpl) start() {
-	sc.Infof("Starting stream consumer for topic. Ver: %s", sc.destination.config.UpdatedAt)
+	sc.Infof("Starting stream consumer for topic. Ver: %s", sc.destination.destinationConfig.UpdatedAt)
 	safego.RunWithRestart(func() {
 		var err error
 		for {
@@ -237,7 +238,7 @@ func (sc *StreamConsumerImpl) start() {
 				}
 				if err != nil {
 					originalError := err
-					failedTopic, _ := MakeTopicId(sc.destination.Id(), retryTopicMode, allTablesToken, false)
+					failedTopic, _ := MakeTopicId(sc.destination.Id(), retryTopicMode, allTablesToken, sc.config.KafkaTopicPrefix, false)
 					retries, err := kafkabase.GetKafkaIntHeader(message, retriesCountHeader)
 					if err != nil {
 						sc.Errorf("failed to read retry header: %v", err)
@@ -251,7 +252,7 @@ func (sc *StreamConsumerImpl) start() {
 					if retries >= sc.config.MessagesRetryCount {
 						//no attempts left - send to dead-letter topic
 						status = "deadLettered"
-						failedTopic, _ = MakeTopicId(sc.destination.Id(), deadTopicMode, allTablesToken, false)
+						failedTopic, _ = MakeTopicId(sc.destination.Id(), deadTopicMode, allTablesToken, sc.config.KafkaTopicPrefix, false)
 					}
 					headers := message.Headers
 					kafkabase.PutKafkaHeader(&headers, errorHeader, originalError.Error())
@@ -290,7 +291,7 @@ func (sc *StreamConsumerImpl) Retire() {
 		return
 	default:
 	}
-	sc.Infof("Closing stream consumer. Ver: %s", sc.destination.config.UpdatedAt)
+	sc.Infof("Closing stream consumer. Ver: %s", sc.destination.destinationConfig.UpdatedAt)
 	close(sc.closed)
 	sc.destination.Release()
 	//TODO: wait for closing?
@@ -299,7 +300,7 @@ func (sc *StreamConsumerImpl) Retire() {
 
 // UpdateDestination
 func (sc *StreamConsumerImpl) UpdateDestination(destination *Destination) error {
-	sc.Infof("[Updating stream consumer for topic. Ver: %s", sc.destination.config.UpdatedAt)
+	sc.Infof("[Updating stream consumer for topic. Ver: %s", sc.destination.destinationConfig.UpdatedAt)
 
 	//create new stream
 	var bs bulker.BulkerStream

--- a/bulkerapp/app/stream_consumer.go
+++ b/bulkerapp/app/stream_consumer.go
@@ -181,7 +181,7 @@ func (sc *StreamConsumerImpl) restartConsumer() {
 
 // start consuming messages from kafka
 func (sc *StreamConsumerImpl) start() {
-	sc.Infof("Starting stream consumer for topic. Ver: %s", sc.destination.destinationConfig.UpdatedAt)
+	sc.Infof("Starting stream consumer for topic. Ver: %s", sc.destination.config.UpdatedAt)
 	safego.RunWithRestart(func() {
 		var err error
 		for {
@@ -291,7 +291,7 @@ func (sc *StreamConsumerImpl) Retire() {
 		return
 	default:
 	}
-	sc.Infof("Closing stream consumer. Ver: %s", sc.destination.destinationConfig.UpdatedAt)
+	sc.Infof("Closing stream consumer. Ver: %s", sc.destination.config.UpdatedAt)
 	close(sc.closed)
 	sc.destination.Release()
 	//TODO: wait for closing?
@@ -300,7 +300,7 @@ func (sc *StreamConsumerImpl) Retire() {
 
 // UpdateDestination
 func (sc *StreamConsumerImpl) UpdateDestination(destination *Destination) error {
-	sc.Infof("[Updating stream consumer for topic. Ver: %s", sc.destination.destinationConfig.UpdatedAt)
+	sc.Infof("[Updating stream consumer for topic. Ver: %s", sc.destination.config.UpdatedAt)
 
 	//create new stream
 	var bs bulker.BulkerStream

--- a/bulkerapp/app/topic_manager.go
+++ b/bulkerapp/app/topic_manager.go
@@ -322,10 +322,10 @@ func (tm *TopicManager) processMetadata(metadata *kafka.Metadata, nonEmptyTopics
 				dstTopics.Remove(topic)
 			}
 		}
-		if destination.destinationConfig.Special == "backup" || destination.destinationConfig.Special == "metrics" {
+		if destination.config.Special == "backup" || destination.config.Special == "metrics" {
 			// create predefined tables for special kind of destinations: backup and metrics
-			tables := []string{destination.destinationConfig.Special}
-			if destination.destinationConfig.Special == "metrics" {
+			tables := []string{destination.config.Special}
+			if destination.config.Special == "metrics" {
 				tables = append(tables, "active_incoming")
 			}
 			for _, table := range tables {

--- a/bulkerapp/app/topic_manager_test.go
+++ b/bulkerapp/app/topic_manager_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMakeTopicId(t *testing.T) {
@@ -15,7 +16,7 @@ func TestMakeTopicId(t *testing.T) {
 		prefix        string
 		checkLength   bool
 		expected      string
-		assertErr     assert.ErrorAssertionFunc
+		requireErr    require.ErrorAssertionFunc
 	}{
 		{
 			desc:          "should return valid topic ID",
@@ -23,7 +24,7 @@ func TestMakeTopicId(t *testing.T) {
 			mode:          "batch",
 			tableName:     "events",
 			expected:      "in.id.clyzlw-.m.batch.t.events",
-			assertErr:     assert.NoError,
+			requireErr:    require.NoError,
 		},
 		{
 			desc:          "should return valid topic ID with prefix",
@@ -32,7 +33,7 @@ func TestMakeTopicId(t *testing.T) {
 			tableName:     "events",
 			prefix:        "some.prefix.",
 			expected:      "some.prefix.in.id.clyzlw-.m.batch.t.events",
-			assertErr:     assert.NoError,
+			requireErr:    require.NoError,
 		},
 		{
 			desc:          "should return error when checkLength is true and topic ID is too long",
@@ -41,8 +42,7 @@ func TestMakeTopicId(t *testing.T) {
 			tableName:     "events",
 			prefix:        "too.looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong",
 			checkLength:   true,
-			expected:      "",
-			assertErr:     assert.Error,
+			requireErr:    require.Error,
 		},
 	}
 	for _, tC := range testCases {
@@ -51,9 +51,60 @@ func TestMakeTopicId(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			topicId, err := MakeTopicId(tc.destinationId, tc.mode, tc.tableName, tc.prefix, tc.checkLength)
 
-			tc.assertErr(t, err)
+			tc.requireErr(t, err)
 
 			assert.Equal(t, tc.expected, topicId)
+		})
+	}
+}
+
+func TestParseTopicId(t *testing.T) {
+	testCases := []struct {
+		desc                  string
+		topic                 string
+		expectedDestinationId string
+		expectedMode          string
+		expectedTableName     string
+		requireErr            require.ErrorAssertionFunc
+	}{
+		{
+			desc:                  "should parse a batch events topic",
+			topic:                 "in.id.clyzlw9m10006az0lhwqg34u9-pq7h-vjyr-gKxdFT.m.batch.t.events",
+			expectedDestinationId: "clyzlw9m10006az0lhwqg34u9-pq7h-vjyr-gKxdFT",
+			expectedMode:          "batch",
+			expectedTableName:     "events",
+			requireErr:            require.NoError,
+		},
+		{
+			desc:                  "should parse a batch events topic with prefix",
+			topic:                 "prefix.with.dots.in.id.clyzlw9m10006az0lhwqg34u9-pq7h-vjyr-gKxdFT.m.batch.t.events",
+			expectedDestinationId: "clyzlw9m10006az0lhwqg34u9-pq7h-vjyr-gKxdFT",
+			expectedMode:          "batch",
+			expectedTableName:     "events",
+			requireErr:            require.NoError,
+		},
+		{
+			desc:       "should return error when 'in.id' is missing",
+			topic:      "clyzlw9m10006az0lhwqg34u9-pq7h-vjyr-gKxdFT.m.batch.t.events",
+			requireErr: require.Error,
+		},
+		{
+			desc:       "should return error when there are too many sub-strings",
+			topic:      "in.id.extra-substring.clyzlw9m10006az0lhwqg34u9-pq7h-vjyr-gKxdFT.m.batch.t.events",
+			requireErr: require.Error,
+		},
+	}
+	for _, tC := range testCases {
+		tc := tC
+
+		t.Run(tC.desc, func(t *testing.T) {
+			destinationId, mode, tableName, err := ParseTopicId(tc.topic)
+
+			tc.requireErr(t, err)
+
+			assert.Equal(t, tc.expectedDestinationId, destinationId)
+			assert.Equal(t, tc.expectedMode, mode)
+			assert.Equal(t, tc.expectedTableName, tableName)
 		})
 	}
 }

--- a/bulkerapp/app/topic_manager_test.go
+++ b/bulkerapp/app/topic_manager_test.go
@@ -1,0 +1,59 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMakeTopicId(t *testing.T) {
+	testCases := []struct {
+		desc          string
+		destinationId string
+		mode          string
+		tableName     string
+		prefix        string
+		checkLength   bool
+		expected      string
+		assertErr     assert.ErrorAssertionFunc
+	}{
+		{
+			desc:          "should return valid topic ID",
+			destinationId: "clyzlw-",
+			mode:          "batch",
+			tableName:     "events",
+			expected:      "in.id.clyzlw-.m.batch.t.events",
+			assertErr:     assert.NoError,
+		},
+		{
+			desc:          "should return valid topic ID with prefix",
+			destinationId: "clyzlw-",
+			mode:          "batch",
+			tableName:     "events",
+			prefix:        "some.prefix.",
+			expected:      "some.prefix.in.id.clyzlw-.m.batch.t.events",
+			assertErr:     assert.NoError,
+		},
+		{
+			desc:          "should return error when checkLength is true and topic ID is too long",
+			destinationId: "clyzlw-",
+			mode:          "batch",
+			tableName:     "events",
+			prefix:        "too.looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong",
+			checkLength:   true,
+			expected:      "",
+			assertErr:     assert.Error,
+		},
+	}
+	for _, tC := range testCases {
+		tc := tC
+
+		t.Run(tc.desc, func(t *testing.T) {
+			topicId, err := MakeTopicId(tc.destinationId, tc.mode, tc.tableName, tc.prefix, tc.checkLength)
+
+			tc.assertErr(t, err)
+
+			assert.Equal(t, tc.expected, topicId)
+		})
+	}
+}

--- a/ingest/router.go
+++ b/ingest/router.go
@@ -193,7 +193,7 @@ type BatchPayload struct {
 func (r *Router) sendToRotor(c *gin.Context, ingestMessageBytes []byte, stream *StreamWithDestinations, sendResponse bool) (asyncDestinations []string, tagsDestinations []string, rError *appbase.RouterError) {
 	var err error
 	if stream.BackupEnabled {
-		backupTopic := fmt.Sprintf("in.id.%s_backup.m.batch.t.backup", stream.Stream.WorkspaceId)
+		backupTopic := fmt.Sprintf("%sin.id.%s_backup.m.batch.t.backup", r.config.KafkaTopicPrefix, stream.Stream.WorkspaceId)
 		err2 := r.producer.ProduceAsync(backupTopic, uuid.New(), ingestMessageBytes, nil, kafka.PartitionAny)
 		if err2 != nil {
 			r.Errorf("Error producing to backup topic %s: %v", backupTopic, err2)

--- a/kafkabase/kafka_config.go
+++ b/kafkabase/kafka_config.go
@@ -2,6 +2,7 @@ package kafkabase
 
 import (
 	"fmt"
+
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 	"github.com/hjson/hjson-go/v4"
 	"github.com/jitsucom/bulker/jitsubase/appbase"
@@ -20,6 +21,7 @@ type KafkaConfig struct {
 	KafkaTopicCompression    string `mapstructure:"KAFKA_TOPIC_COMPRESSION" default:"snappy"`
 	KafkaTopicRetentionHours int    `mapstructure:"KAFKA_TOPIC_RETENTION_HOURS" default:"48"`
 	KafkaTopicSegmentHours   int    `mapstructure:"KAFKA_TOPIC_SEGMENT_HOURS" default:"24"`
+	KafkaTopicPrefix         string `mapstructure:"KAFKA_TOPIC_PREFIX" default:""`
 
 	KafkaRetryTopicSegmentBytes              int    `mapstructure:"KAFKA_RETRY_TOPIC_SEGMENT_BYTES" default:"104857600"`
 	KafkaDeadTopicRetentionHours             int    `mapstructure:"KAFKA_DEAD_TOPIC_RETENTION_HOURS" default:"168"`


### PR DESCRIPTION
Add an optional `BULKER_KAFKA_TOPIC_PREFIX` for the Destination Kafka topics (i.e. the `in.id` ones):
https://github.com/jitsucom/bulker/blob/main/.docs/server-config.md#kafka-topic-management-advanced

This allows topics, for example, to be named according to an org's convention.

Original discussion: https://jitsuhq.slack.com/archives/C018G6W0URG/p1722244485117179

I've tried to minimize the blast radius of the PR, focusing on `topic_manager.go`.

I think I caught every piece of code that depends on topic names, but please review judiciously, I may have missed something.