### PR TITLE
ingest: make backup topic name compliant with k8s RFC 1123

### DIFF
--- a/ingest/router.go
+++ b/ingest/router.go
@@ -5,6 +5,16 @@ import (
 	"crypto/sha512"
 	"encoding/base64"
 	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"net/http/pprof"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/confluentinc/confluent-kafka-go/v2/kafka"
 	"github.com/gin-gonic/gin"
 	"github.com/jitsucom/bulker/eventslog"
@@ -17,15 +27,6 @@ import (
 	"github.com/jitsucom/bulker/jitsubase/uuid"
 	"github.com/jitsucom/bulker/kafkabase"
 	"github.com/penglongli/gin-metrics/ginmetrics"
-	"io"
-	"math/rand"
-	"net/http"
-	"net/http/pprof"
-	"net/url"
-	"regexp"
-	"strconv"
-	"strings"
-	"time"
 )
 
 var eventTypesDict = map[string]string{
@@ -195,7 +196,7 @@ type BatchPayload struct {
 func (r *Router) sendToRotor(c *gin.Context, ingestMessageBytes []byte, stream *StreamWithDestinations, sendResponse bool) (asyncDestinations []string, tagsDestinations []string, rError *appbase.RouterError) {
 	var err error
 	if stream.BackupEnabled {
-		backupTopic := fmt.Sprintf("%sin.id.%s_backup.m.batch.t.backup", r.config.KafkaTopicPrefix, stream.Stream.WorkspaceId)
+		backupTopic := fmt.Sprintf("%sin.id.%s.backup.m.batch.t.backup", r.config.KafkaTopicPrefix, stream.Stream.WorkspaceId)
 		err2 := r.producer.ProduceAsync(backupTopic, uuid.New(), ingestMessageBytes, nil, kafka.PartitionAny)
 		if err2 != nil {
 			r.Errorf("Error producing to backup topic %s: %v", backupTopic, err2)


### PR DESCRIPTION
## What

Change the backup topic name to use `.` instead of `_`.

## Why

Rather than allowing Jitsu to create topics, we create all Kafka topics beforehand as Kubernetes resources via GitOps, which means they must obey the RFC 1123 naming convention:
https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names

When we try to create the topic, we get this error message:
```
The KafkaTopic "jitsu.in.id.clzl4ctq800063k0j1tv8g9dg_backup.m.batch.t.backup" is invalid: metadata.name: Invalid value: "jitsu.in.id.clzl4ctq800063k0j1tv8g9dg_backup.m.batch.t.backup": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
```

The offending char seems to be the `_`, as it's not part of the regex.