### PR TITLE
kafkabase: Add support for custom CA certificate in Kafka SSL configuration

### DIFF
--- a/.docs/server-config.md
+++ b/.docs/server-config.md
@@ -83,6 +83,14 @@ List of Kafka brokers separated by comma. Each broker should be in format `host:
 
 If SSL should be enabled
 
+### `BULKER_KAFKA_SSL_CA`
+
+CA certificate string (PEM format) for verifying the broker's key.
+
+### `BULKER_KAFKA_SSL_CA_FILE`
+
+File path to CA certificate for verifying the broker's key.
+
 ### `BULKER_KAFKA_SSL_SKIP_VERIFY`
 
 Skip SSL verification of kafka server certificate.

--- a/kafkabase/kafka_config.go
+++ b/kafkabase/kafka_config.go
@@ -13,7 +13,10 @@ type KafkaConfig struct {
 	KafkaBootstrapServers string `mapstructure:"KAFKA_BOOTSTRAP_SERVERS"`
 	KafkaSSL              bool   `mapstructure:"KAFKA_SSL" default:"false"`
 	KafkaSSLSkipVerify    bool   `mapstructure:"KAFKA_SSL_SKIP_VERIFY" default:"false"`
-	//Kafka authorization as JSON object {"mechanism": "SCRAM-SHA-256|PLAIN", "username": "user", "password": "password"}
+	KafkaSSLCA            string `mapstructure:"KAFKA_SSL_CA"`
+	KafkaSSLCAFile        string `mapstructure:"KAFKA_SSL_CA_FILE"`
+
+	// Kafka authorization as JSON object {"mechanism": "SCRAM-SHA-256|PLAIN", "username": "user", "password": "password"}
 	KafkaSASL string `mapstructure:"KAFKA_SASL"`
 
 	KafkaSessionTimeoutMs    int    `mapstructure:"KAFKA_SESSION_TIMEOUT_MS" default:"45000"`
@@ -62,6 +65,12 @@ func (ac *KafkaConfig) GetKafkaConfig() *kafka.ConfigMap {
 		}
 		if ac.KafkaSSLSkipVerify {
 			_ = kafkaConfig.SetKey("enable.ssl.certificate.verification", false)
+		}
+		if ac.KafkaSSLCA != "" {
+			_ = kafkaConfig.SetKey("ssl.ca.pem", ac.KafkaSSLCA)
+		}
+		if ac.KafkaSSLCAFile != "" {
+			_ = kafkaConfig.SetKey("ssl.ca.location", ac.KafkaSSLCAFile)
 		}
 	}
 	if ac.KafkaSASL != "" {


### PR DESCRIPTION
This PR introduces support for the `<BULKER|INGEST>_KAFKA_SSL_CA` and `<BULKER|INGEST>_KAFKA_SSL_CA_FILE` environment variables, following the changes made in https://github.com/jitsucom/jitsu/pull/1175. These variables allow specifying a custom CA certificate or its file path for Kafka server certificate verification.
