### PR TITLE
bulker: Add configurable retention time for retry topic

### DIFF
--- a/.docs/server-config.md
+++ b/.docs/server-config.md
@@ -196,13 +196,19 @@ e.g. if `BULKER_KAFKA_TOPIC_PREFIX=some.prefix.`, then a full topic name could b
 
 ### `BULKER_KAFKA_TOPIC_RETENTION_HOURS`
 
-*Optional, default value: `168` (7 days)*
+*Optional, default value: `48` (2 days)*
 
 Main topic retention time in hours.
 
+### `BULKER_KAFKA_TOPIC_SEGMENT_HOURS`
+
+*Optional, default value: `24` (1 day)*
+
+Maximum time in hours Kafka waits before creating a new log segment (see `segment.ms` in Kafka). Applies to all topic types.
+
 ### `BULKER_KAFKA_RETRY_TOPIC_RETENTION_HOURS`
 
-*Optional, default value: `168` (7 days)*
+*Optional, default value: `48` (2 days)*
 
 Topic for retried events retention time in hours.
 

--- a/bulkerapp/app/topic_manager.go
+++ b/bulkerapp/app/topic_manager.go
@@ -99,7 +99,7 @@ func NewTopicManager(appContext *Context) (*TopicManager, error) {
 			retryTopicMode: {
 				"cleanup.policy": "delete,compact",
 				"segment.bytes":  fmt.Sprint(appContext.config.KafkaRetryTopicSegmentBytes),
-				"retention.ms":   fmt.Sprint(appContext.config.KafkaTopicRetentionHours * 60 * 60 * 1000),
+				"retention.ms":   fmt.Sprint(appContext.config.KafkaRetryTopicRetentionHours * 60 * 60 * 1000),
 				"segment.ms":     fmt.Sprint(appContext.config.KafkaTopicSegmentHours * 60 * 60 * 1000),
 			},
 			deadTopicMode: {
@@ -373,7 +373,7 @@ func (tm *TopicManager) processMetadata(metadata *kafka.Metadata, nonEmptyTopics
 	err = tm.ensureTopic(destinationsRetryTopicName, 1, map[string]string{
 		"cleanup.policy": "delete,compact",
 		"segment.bytes":  fmt.Sprint(tm.config.KafkaRetryTopicSegmentBytes),
-		"retention.ms":   fmt.Sprint(tm.config.KafkaTopicRetentionHours * 60 * 60 * 1000),
+		"retention.ms":   fmt.Sprint(tm.config.KafkaRetryTopicRetentionHours * 60 * 60 * 1000),
 		"segment.ms":     fmt.Sprint(tm.config.KafkaTopicSegmentHours * 60 * 60 * 1000),
 	})
 	if err != nil {

--- a/kafkabase/kafka_config.go
+++ b/kafkabase/kafka_config.go
@@ -28,6 +28,7 @@ type KafkaConfig struct {
 	KafkaFetchMessageMaxBytes int    `mapstructure:"KAFKA_FETCH_MESSAGE_MAX_BYTES" default:"1048576"`
 
 	KafkaRetryTopicSegmentBytes              int    `mapstructure:"KAFKA_RETRY_TOPIC_SEGMENT_BYTES" default:"104857600"`
+	KafkaRetryTopicRetentionHours            int    `mapstructure:"KAFKA_RETRY_TOPIC_RETENTION_HOURS" default:"48"`
 	KafkaDeadTopicRetentionHours             int    `mapstructure:"KAFKA_DEAD_TOPIC_RETENTION_HOURS" default:"168"`
 	KafkaTopicReplicationFactor              int    `mapstructure:"KAFKA_TOPIC_REPLICATION_FACTOR"`
 	KafkaAdminMetadataTimeoutMs              int    `mapstructure:"KAFKA_ADMIN_METADATA_TIMEOUT_MS" default:"1000"`


### PR DESCRIPTION
## Overview

This PR includes the following updates related to Kafka env variables:
1. Add documentation for `BULKER_KAFKA_TOPIC_SEGMENT_HOURS` - added a description for the environment variable in the documentation to clarify its purpose and default value (24h).
2. Correct default value for `BULKER_KAFKA_TOPIC_RETENTION_HOURS` in the documentation - fixed the default value for the environment variable to reflect the actual setting.
3. Fix code to use `KAFKA_RETRY_TOPIC_RETENTION_HOURS` - updated the code to properly use the environment variable, which was documented but not used in the code.
