### PR TITLE
Optional kafka segment configs

### DIFF
--- a/bulkerapp/app/batch_consumer.go
+++ b/bulkerapp/app/batch_consumer.go
@@ -259,7 +259,7 @@ func (bc *BatchConsumerImpl) processFailed(firstPosition *kafka.TopicPartition, 
 		}
 
 	}()
-	err = bc.topicManager.ensureTopic(bc.retryTopic, 1, bc.topicManager.RetryTopicConfig())
+	err = bc.topicManager.ensureTopic(bc.retryTopic, 1, bc.topicManager.config.TopicConfig("retry"))
 	if err != nil {
 		return counters, fmt.Errorf("failed to create retry topic %s: %v", bc.retryTopic, err)
 	}

--- a/bulkerapp/app/stream_consumer.go
+++ b/bulkerapp/app/stream_consumer.go
@@ -282,7 +282,7 @@ func (sc *StreamConsumerImpl) start() {
 						metrics.ConnectionMessageStatuses(sc.destination.Id(), sc.tableName, "deadLettered").Inc()
 						failedTopic = sc.config.KafkaDestinationsDeadLetterTopicName
 					} else {
-						err = sc.topicManager.ensureTopic(sc.retryTopic, 1, sc.topicManager.RetryTopicConfig())
+						err = sc.topicManager.ensureTopic(sc.retryTopic, 1, sc.topicManager.config.TopicConfig("retry"))
 						if err != nil {
 							sc.Errorf("failed to create retry topic %s: %v", sc.retryTopic, err)
 						}

--- a/bulkerapp/app/topic_manager.go
+++ b/bulkerapp/app/topic_manager.go
@@ -658,15 +658,6 @@ func (tm *TopicManager) createTopic(topic string, partitions int, config map[str
 	return nil
 }
 
-func (tm *TopicManager) RetryTopicConfig() map[string]string {
-	return map[string]string{
-		"cleanup.policy": "delete,compact",
-		"segment.bytes":  fmt.Sprint(tm.config.KafkaRetryTopicSegmentBytes),
-		"retention.ms":   fmt.Sprint(tm.config.KafkaRetryTopicRetentionHours * 60 * 60 * 1000),
-		"segment.ms":     fmt.Sprint(tm.config.KafkaTopicSegmentHours * 60 * 60 * 1000),
-	}
-}
-
 func (tm *TopicManager) Refresh() {
 	select {
 	case tm.refreshChan <- true:

--- a/kafkabase/kafka_config.go
+++ b/kafkabase/kafka_config.go
@@ -24,6 +24,7 @@ type KafkaConfig struct {
 	KafkaTopicCompression     string `mapstructure:"KAFKA_TOPIC_COMPRESSION" default:"snappy"`
 	KafkaTopicRetentionHours  int    `mapstructure:"KAFKA_TOPIC_RETENTION_HOURS" default:"48"`
 	KafkaTopicSegmentHours    int    `mapstructure:"KAFKA_TOPIC_SEGMENT_HOURS" default:"24"`
+	KafkaAllowSegmentConfig   bool   `mapstructure:"KAFKA_ALLOW_SEGMENT_CONFIG" default:"true"`
 	KafkaTopicPrefix          string `mapstructure:"KAFKA_TOPIC_PREFIX" default:""`
 	KafkaFetchMessageMaxBytes int    `mapstructure:"KAFKA_FETCH_MESSAGE_MAX_BYTES" default:"1048576"`
 
@@ -89,6 +90,34 @@ func (ac *KafkaConfig) GetKafkaConfig() *kafka.ConfigMap {
 	}
 
 	return kafkaConfig
+}
+
+func (c *KafkaConfig) TopicConfig(mode string) map[string]string {
+	config := map[string]string{}
+
+	switch mode {
+	case "retry":
+		config["retention.ms"] = fmt.Sprint(c.KafkaTopicRetentionHours * 60 * 60 * 1000)
+		config["cleanup.policy"] = "delete,compact"
+
+		if c.KafkaAllowSegmentConfig {
+			config["segment.bytes"] = fmt.Sprint(c.KafkaRetryTopicSegmentBytes)
+			config["segment.ms"] = fmt.Sprint(c.KafkaTopicSegmentHours * 60 * 60 * 1000)
+		}
+	case "dead":
+		config["retention.ms"] = fmt.Sprint(c.KafkaDeadTopicRetentionHours * 60 * 60 * 1000)
+		config["cleanup.policy"] = "delete,compact"
+		if c.KafkaAllowSegmentConfig {
+			config["segment.ms"] = fmt.Sprint(c.KafkaTopicSegmentHours * 60 * 60 * 1000)
+		}
+	default:
+		config["compression.type"] = c.KafkaTopicCompression
+		config["retention.ms"] = fmt.Sprint(c.KafkaTopicRetentionHours * 60 * 60 * 1000)
+		if c.KafkaAllowSegmentConfig {
+			config["segment.ms"] = fmt.Sprint(c.KafkaTopicSegmentHours * 60 * 60 * 1000)
+		}
+	}
+	return config
 }
 
 func (c *KafkaConfig) PostInit(settings *appbase.AppSettings) error {


### PR DESCRIPTION
This is an attempt to make kafka segment configs optional so bulker can work with providers that do not allow clients to set those configs, AWS MSK for example.