### PR TITLE
feat: allow security protocol

### DIFF
--- a/.docs/server-config.md
+++ b/.docs/server-config.md
@@ -101,7 +101,7 @@ Kafka authorization as JSON object `{"mechanism": "SCRAM-SHA-256|PLAIN", "userna
 
 ### `BULKER_KAFKA_SECURITY_PROTOCOL`
 
-Allow to pass security.protocol
+Allows setting Kafka `security.protocol`
 
 
 ## Batching

--- a/.docs/server-config.md
+++ b/.docs/server-config.md
@@ -99,6 +99,10 @@ Skip SSL verification of kafka server certificate.
 
 Kafka authorization as JSON object `{"mechanism": "SCRAM-SHA-256|PLAIN", "username": "user", "password": "password"}`
 
+### `BULKER_KAFKA_SECURITY_PROTOCOL`
+
+Allow to pass security.protocol
+
 
 ## Batching
 

--- a/kafkabase/kafka_config.go
+++ b/kafkabase/kafka_config.go
@@ -15,6 +15,7 @@ type KafkaConfig struct {
 	KafkaSSLSkipVerify    bool   `mapstructure:"KAFKA_SSL_SKIP_VERIFY" default:"false"`
 	KafkaSSLCA            string `mapstructure:"KAFKA_SSL_CA"`
 	KafkaSSLCAFile        string `mapstructure:"KAFKA_SSL_CA_FILE"`
+	KafkaSecurityProtocol string `mapstructure:"KAFKA_SECURITY_PROTOCOL"`
 
 	// Kafka authorization as JSON object {"mechanism": "SCRAM-SHA-256|PLAIN", "username": "user", "password": "password"}
 	KafkaSASL string `mapstructure:"KAFKA_SASL"`
@@ -48,7 +49,7 @@ type KafkaConfig struct {
 	ProducerBatchSize          int     `mapstructure:"PRODUCER_BATCH_SIZE" default:"65535"`
 	ProducerLingerMs           int     `mapstructure:"PRODUCER_LINGER_MS" default:"1000"`
 	ProducerWaitForDeliveryMs  int     `mapstructure:"PRODUCER_WAIT_FOR_DELIVERY_MS" default:"1000"`
-	
+
 	// Failover logger configuration
 	FailoverLoggerEnvConfig `mapstructure:",squash"`
 }
@@ -89,6 +90,10 @@ func (ac *KafkaConfig) GetKafkaConfig() *kafka.ConfigMap {
 		for k, v := range sasl {
 			_ = kafkaConfig.SetKey("sasl."+k, v)
 		}
+	}
+
+	if ac.KafkaSecurityProtocol != "" {
+		_ = kafkaConfig.SetKey("security.protocol", ac.KafkaSecurityProtocol)
 	}
 
 	return kafkaConfig


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds support for configuring Kafka security.protocol via BULKER_KAFKA_SECURITY_PROTOCOL to work with secure clusters (e.g., SASL_SSL). No change in default behavior unless the var is set.

- **New Features**
  - New config: KAFKA_SECURITY_PROTOCOL → sets security.protocol when provided.
  - Docs: added BULKER_KAFKA_SECURITY_PROTOCOL env var usage.

<!-- End of auto-generated description by cubic. -->

